### PR TITLE
make pairing header linkable

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,6 +1,7 @@
 ## Prerequisites
-
 You must have a BitPay merchant account to use this library.  It's free to [sign-up for a BitPay merchant account](https://bitpay.com/start).
+
+Once you have a BitPay merchant account, you will need [a working BitPay Access Token](/api/getting-access.html) – this can be done either [via the library](#pairing) or manually in [the BitPay Dashboard](https://bitpay.com/tokens).
 
 
 ## Getting Started
@@ -30,8 +31,7 @@ ECKey key = KeyUtils.createEcKeyFromHexString(privateKey);
 this.bitpay = new BitPay(key);
 ```
 
-## Pair your client with BitPay
-
+## Pairing
 Your client must be paired with the BitPay server.  The pairing initializes authentication and authorization for your client to communicate with BitPay for your specific merchant account.  There are two pairing modes available; client initiated and server initiated.
 
 ### Client initiated pairing

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,3 +1,4 @@
+# Using BitPay Java Client Library
 ## Prerequisites
 You must have a BitPay merchant account to use this library.  It's free to [sign-up for a BitPay merchant account](https://bitpay.com/start).
 


### PR DESCRIPTION
This makes the "pairing" section linkable via simply `#pairing` – I'd like for each of the libraries to follow this pattern.

Similarly, I'd like each of the libraries to expose a standard "Prerequisites" section following this files' format, with the links included.