### PR TITLE
SP-23 autoRedirect should set the value on the invoice

### DIFF
--- a/src/main/java/com/bitpay/sdk/model/Invoice/Invoice.java
+++ b/src/main/java/com/bitpay/sdk/model/Invoice/Invoice.java
@@ -375,7 +375,7 @@ public class Invoice {
         this._itemizedDetails = _itemizedDetails;
     }
 
-    @JsonIgnore
+    @JsonProperty("autoRedirect")
     public boolean getAutoRedirect() {
         return _autoRedirect;
     }


### PR DESCRIPTION
# Overview
The `autoRedirect` property on an Invoice was being ignored due to the `@JsonIgnore` annotation. We've removed the annotation and mapped it to a property so that it can be used, then tested the following scenarios:
1. `autoRedirect: true`, redirectUrl supplied
2. `autoRedirect: false`
3. `autoRedirect: true`, redirectUrl not supplied