### PR TITLE
SP-44 forcedBuyerSelectedTransactionCurrency should set the value on the invoice

### DIFF
--- a/src/main/java/com/bitpay/sdk/model/Invoice/Invoice.java
+++ b/src/main/java/com/bitpay/sdk/model/Invoice/Invoice.java
@@ -424,7 +424,7 @@ public class Invoice {
     // Response fields
     //
     
-    @JsonIgnore
+    @JsonProperty("forcedBuyerSelectedTransactionCurrency")
     public String getForcedBuyerSelectedTransactionCurrency() {
         return _forcedBuyerSelectedTransactionCurrency;
     }


### PR DESCRIPTION
# Overview
The `forcedBuyerSelectedTransactionCurrency` property on an Invoice was being ignored due to the `@JsonIgnore` annotation. We've removed the annotation and mapped it to a property so that it can be used, then tested the following scenarios:
1. `forcedBuyerSelectedTransactionCurrency: "BCH"`
2. `forcedBuyerSelectedTransactionCurrency: (empty)`