### PR TITLE
Java 21 JaCoCo support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.11</version>
                 <executions>
                     <execution>
                         <goals>
@@ -278,12 +278,12 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.11</version>
+            <version>1.14.12</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
# Overview

We were getting a lot of errors with JaCoCo on Java 21, so we needed to update dependencies. Tests were passing, but the output was messy because of an incompatibility.

# What's Changed

- Updated jacoco-maven-plugin to 0.8.11
- Updated byte-buddy to 1.14.12
- Updated commons-io to 2.15.1