### PR TITLE
Security: Fix untrusted input vulnerability in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,17 @@ jobs:
     name: Publish changelog to Readme
     runs-on: ubuntu-latest
     steps:
-      - name: Extract release data
-        id: release
-        run: |
-          echo "title=${{ github.event.release.name }}" >> $GITHUB_OUTPUT
-          {
-            echo "body<<EOF"
-            echo "${{ github.event.release.body }}"
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
-
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Publish changelog to Readme
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
+          RELEASE_TITLE: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          jq -n --arg title "Java Unified SDK ${{ steps.release.outputs.title }}" \
-                --arg body "${{ steps.release.outputs.body }}" \
+          jq -n --arg title "Java Unified SDK $RELEASE_TITLE" \
+                --arg body "$RELEASE_BODY" \
                 '{
                   title: $title,
                   content: {


### PR DESCRIPTION
## Security Fix: Prevent Command Injection in Release Workflow

### Summary
This PR fixes a command injection vulnerability in the GitHub Actions release workflow by moving all untrusted inputs and GitHub context variables to environment variables.

### Problem
The workflow was directly interpolating user inputs and GitHub context variables into shell commands, which could allow command injection attacks. Specifically:

- `${{ github.event.release.name }}` - GitHub context variable
- `${{ github.event.release.body }}` - GitHub context variable

### Solution
All potentially untrusted values are now passed through environment variables before being used in shell commands. This ensures they are treated as literal strings rather than being evaluated as code.

**Changes made:**
1. Removed the intermediate extraction step that passed untrusted input through GITHUB_OUTPUT
2. Changed to use environment variables (`RELEASE_TITLE`, `RELEASE_BODY`) to safely pass GitHub event data
3. Updated script to reference environment variables instead of directly interpolating GitHub context expressions

### Security Impact
This follows the security best practices outlined in the [GitHub Security Lab advisory](https://securitylab.github.com/resources/github-actions-untrusted-input/) and prevents potential command injection through GitHub Actions expressions.

### Testing
- [ ] Workflow syntax is valid
- [ ] No functional changes to workflow behavior
- [ ] All steps continue to work as expected