### PR TITLE
[#420] Add Java 25 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8, 11, 17, 21, 23]
+        java-version: [8, 11, 17, 21, 23, 25]
     
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'corretto'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: 8
           distribution: 'corretto'

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bitpay</groupId>
     <artifactId>bitpay_sdk</artifactId>
-    <version>10.2.5</version>
+    <version>10.3.0</version>
     <packaging>jar</packaging>
 
     <name>BitPay</name>

--- a/src/main/java/com/bitpay/sdk/Config.java
+++ b/src/main/java/com/bitpay/sdk/Config.java
@@ -34,7 +34,7 @@ public class Config {
     /**
      * BitPay Plugin Info Version.
      */
-    public static final String BITPAY_PLUGIN_INFO = "BitPay_Java_Client_v10.2.5";
+    public static final String BITPAY_PLUGIN_INFO = "BitPay_Java_Client_v10.3.0";
     /**
      * BitPay Api Frame.
      */

--- a/src/main/java/com/bitpay/sdk/util/KeyUtils.java
+++ b/src/main/java/com/bitpay/sdk/util/KeyUtils.java
@@ -48,6 +48,11 @@ public class KeyUtils {
     public static boolean privateKeyExists(String privateKeyFile) {
         PrivateKeyFile = privateKeyFile;
 
+        // if the private key file is null or empty, return false
+        if (privateKeyFile == null || privateKeyFile.isEmpty()) {
+            return false;
+        }
+
         return new File(privateKeyFile).exists();
     }
 

--- a/src/test/java/com/bitpay/sdk/ConfigTest.java
+++ b/src/test/java/com/bitpay/sdk/ConfigTest.java
@@ -58,7 +58,7 @@ public class ConfigTest {
 
     @Test
     public void it_should_returns_bitpay_plugin_info() {
-        Assertions.assertTrue(Config.BITPAY_PLUGIN_INFO.contains("BitPay_Java_Client_v10.2.5"));
+        Assertions.assertTrue(Config.BITPAY_PLUGIN_INFO.contains("BitPay_Java_Client_v10.3.0"));
     }
 
     @Test


### PR DESCRIPTION
### Summary
This PR adds Java 25 support to the build matrix and updates GitHub Actions to their latest versions. Additionally, includes a bug fix for handling java.io.FileNotFoundException in KeyUtils.

### Changes
1. Java 25 Support
    - Added Java 25 to build matrix in build.yml
    - Ensures the SDK is tested and compatible with the latest Java version
2. GitHub Actions Updates
    - Updated actions/checkout: v4 → v6
    - Updated actions/setup-java: v4 → v5
    - Ensures CI/CD pipelines use the latest action versions with improved performance and security
3. Bug Fix in KeyUtils
    - Enhanced null safety in privateKeyExists() method
    - Added null/empty check for privateKeyFile parameter before file existence check
    - Prevents potential NullPointerException when null or empty string is passed
    - Returns false early if the parameter is invalid

### Testing
- [x] All tests pass on Java 8, 11, 17, 21, 23, and 25
- [x] Build succeeds on all supported Java versions
- [x] Checkstyle validation passes

### Compatibility
- Maintains backward compatibility with Java 8
- No breaking changes to public APIs