### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <slf4j.version>2.0.17</slf4j.version>
-        <jackson.version>2.20.0</jackson.version>
+        <jackson.version>2.21.1</jackson.version>
     </properties>
 
     <build>
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>setup</id>
@@ -228,7 +228,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR updates several Maven dependencies and plugins to their latest versions.

### Dependencies:

- Bump Jackson from 2.20.0 to 2.21.1
- Bump jackson-annotations from 2.20 to 2.21

### Maven Plugins:

- Bump maven-source-plugin from 3.3.1 to 3.4.0
- Bump exec-maven-plugin from 3.6.2 to 3.6.3