### PR TITLE
[#444] Update Maven properties for Java compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <slf4j.version>2.0.18</slf4j.version>
         <jackson.version>2.21.3</jackson.version>
-        <junit.version>5.9.3</junit.version>
-        <mockito.version>4.11.0</mockito.version>
+        <junit.version>6.1.0</junit.version>
+        <mockito.version>5.23.0</mockito.version>
     </properties>
 
     <build>
@@ -192,15 +192,15 @@
 
     <profiles>
         <profile>
-            <id>java11plus</id>
+            <id>java11minus</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>(,12)</jdk>
             </activation>
             <properties>
-                <maven.compiler.source>11</maven.compiler.source>
-                <maven.compiler.target>11</maven.compiler.target>
-                <junit.version>5.14.3</junit.version>
-                <mockito.version>5.23.0</mockito.version>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <junit.version>5.9.3</junit.version>
+                <mockito.version>4.11.0</mockito.version>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <slf4j.version>2.0.18</slf4j.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.22.0</jackson.version>
         <junit.version>6.1.0</junit.version>
         <mockito.version>5.23.0</mockito.version>
     </properties>


### PR DESCRIPTION
### Problem

Dependabot PRs upgrading dependencies (JUnit 6.x and Mockito 5.x) were causing test failures on Java 11 and earlier versions. The newer library versions require Java 12+ and are not backwards compatible.

### Solution

Restructured the Maven configuration to support both modern and legacy Java versions:

#### Default Configuration (Java 12+):

- Java compiler source/target: 11
- JUnit: 6.1.0
- Mockito: 5.23.0

#### Java 11 and Earlier Profile:

- Added java11minus profile that automatically activates for JDK 11 and below
- Java compiler source/target: 1.8
- JUnit: 5.9.3 (compatible with Java 8-11)
- Mockito: 4.11.0 (compatible with Java 8-11)

### Changes

- Updated default dependency versions to latest (Java 12+ compatible)
- Added Maven profile java11minus with activation condition <jdk>(,12)</jdk>
- Profile overrides dependency versions with Java 8-11 compatible versions

### Impact
- Dependabot can now safely upgrade dependencies without breaking Java 11 builds
- Java 12+ users get the latest library versions
- Java 8-11 users continue to have a working build with compatible library versions
- No manual configuration required - Maven automatically selects the appropriate profile based on JDK version