### PR TITLE
[#444] Preserve Java 8 Compatibility with a Profile-Based Build Approach

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,16 +197,14 @@
                 <jdk>(,11)</jdk>
             </activation>
             <properties>
-                <maven.compiler.source>1.8</maven.compiler.source>
-                <maven.compiler.target>1.8</maven.compiler.target>
                 <junit.version>5.9.3</junit.version>
                 <mockito.version>4.11.0</mockito.version>
             </properties>
         </profile>
         <profile>
-            <id>java11</id>
+            <id>java11to16</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[11,17)</jdk>
             </activation>
             <properties>
                 <maven.compiler.source>11</maven.compiler.source>
@@ -215,13 +213,14 @@
             </properties>
         </profile>
         <profile>
-            <id>java11plus</id>
+            <id>java17plus</id>
             <activation>
-                <jdk>(11,)</jdk>
+                <jdk>[17,)</jdk>
             </activation>
             <properties>
                 <maven.compiler.source>11</maven.compiler.source>
                 <maven.compiler.target>11</maven.compiler.target>
+                <junit.version>6.1.0</junit.version>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <slf4j.version>2.0.18</slf4j.version>
         <jackson.version>2.22.0</jackson.version>
         <junit.version>6.1.0</junit.version>
@@ -63,6 +61,14 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -207,8 +213,7 @@
                 <jdk>[11,17)</jdk>
             </activation>
             <properties>
-                <maven.compiler.source>11</maven.compiler.source>
-                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.release>11</maven.compiler.release>
                 <junit.version>5.14.3</junit.version>
             </properties>
         </profile>
@@ -218,8 +223,7 @@
                 <jdk>[17,)</jdk>
             </activation>
             <properties>
-                <maven.compiler.source>11</maven.compiler.source>
-                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.release>11</maven.compiler.release>
                 <junit.version>6.1.0</junit.version>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <slf4j.version>2.0.18</slf4j.version>
         <jackson.version>2.22.0</jackson.version>
         <junit.version>6.1.0</junit.version>
@@ -194,13 +194,34 @@
         <profile>
             <id>java11minus</id>
             <activation>
-                <jdk>(,12)</jdk>
+                <jdk>(,11)</jdk>
             </activation>
             <properties>
                 <maven.compiler.source>1.8</maven.compiler.source>
                 <maven.compiler.target>1.8</maven.compiler.target>
                 <junit.version>5.9.3</junit.version>
                 <mockito.version>4.11.0</mockito.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <junit.version>5.14.3</junit.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>java11plus</id>
+            <activation>
+                <jdk>(11,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
### Summary

This PR ensures the BitPay SDK maintains Java 8 compatibility while allowing development and testing on newer JDK versions. The default compiler target is set to Java 8, with profile-based overrides for JDK 11+.

### Backward Compatibility
Releases built using JDK 8 will produce a published Maven artifact that targets Java 8 bytecode. This ensures:

- Java 8 applications can consume the library
- Java 11+ applications can consume the library (forward compatible)
- No breaking changes for existing consumers
- Maximum compatibility across Java versions 8-25+